### PR TITLE
98 compliance

### DIFF
--- a/read.h
+++ b/read.h
@@ -14,11 +14,11 @@
 template<class T>
 T read(const std::string prompt = "") {
 	while (true) {
+		if (std::cin.eof()) //We reached the end of file, or the user hit ctrl-d
+			return {}; //Alternatively, we could throw an exception
 		T retval{};
 		std::cout << prompt;
 		std::cin >> retval;
-		if (std::cin.eof()) //We reached the end of file, or the user hit ctrl-d
-			return {}; //Alternatively, we could throw an exception
 		if (!std::cin) {
 			std::cin.clear(); //Clear error code
 			std::string s;
@@ -35,10 +35,10 @@ T read(const std::string prompt = "") {
 template<class T>
 T read(std::istream &ins) {
 	while (true) {
-		T retval{};
-		ins >> retval;
 		if (ins.eof()) //We reached the end of file, or the user hit ctrl-d
 			return {};
+		T retval{};
+		ins >> retval;
 		if (!ins) {
 			ins.clear(); //Clear error code
 			std::string s;
@@ -89,11 +89,11 @@ std::string readline(std::istream &ins, char delimiter = '\n') {
 // cout << *a << endl;
 template<class T>
 std::optional<T> read_opt(const std::string prompt = "") {
+	if (std::cin.eof()) //We reached the end of file, or the user hit ctrl-d
+		return std::nullopt;  //Return that nothing was read
 	T retval{};
 	std::cout << prompt;
 	std::cin >> retval;
-	if (std::cin.eof()) //We reached the end of file, or the user hit ctrl-d
-		return std::nullopt;  //Return that nothing was read
 	if (!std::cin) {
 		std::cin.clear(); //Clear error code, so the user can try again when they like
 		return std::nullopt;  //Return that nothing was read
@@ -105,10 +105,10 @@ std::optional<T> read_opt(const std::string prompt = "") {
 //Like the other read_opt, returns nullopt if it didn't read what was expected
 template<class T>
 std::optional<T> read_opt(std::istream &ins) {
-	T retval{};
-	ins >> retval;
 	if (ins.eof()) //We reached the end of file, or the user hit ctrl-d
 		return std::nullopt;  //Return that nothing was read
+	T retval{};
+	ins >> retval;
 	if (!ins) {
 		ins.clear(); //Clear error code, so the user can try again when they like
 		return std::nullopt;  //Return that nothing was read
@@ -129,11 +129,11 @@ struct Reader {
 	template<class T>
 		operator T() {
 			while(true) {
+				if(ins.eof()) //We reached the end of file, or the user hit ctrl-d
+					return {}; //Alternatively, we could throw an exception
 				T retval{};
 				std::cout << prompt;
 				ins >> retval; //If this fails, it's because you need a operator>> defined for your type
-				if(ins.eof()) //We reached the end of file, or the user hit ctrl-d
-					return {}; //Alternatively, we could throw an exception
 				if(!ins) {
 					ins.clear(); //Clear error code
 					std::string s;

--- a/read.h
+++ b/read.h
@@ -15,8 +15,8 @@ template<class T>
 T read(const std::string prompt = "") {
 	while (true) {
 		if (std::cin.eof()) //We reached the end of file, or the user hit ctrl-d
-			return {}; //Alternatively, we could throw an exception
-		T retval{};
+			return T(); //Alternatively, we could throw an exception
+		T retval;
 		std::cout << prompt;
 		std::cin >> retval;
 		if (!std::cin) {
@@ -36,8 +36,8 @@ template<class T>
 T read(std::istream &ins) {
 	while (true) {
 		if (ins.eof()) //We reached the end of file, or the user hit ctrl-d
-			return {};
-		T retval{};
+			return T();
+		T retval;
 		ins >> retval;
 		if (!ins) {
 			ins.clear(); //Clear error code
@@ -119,19 +119,20 @@ std::optional<T> read_opt(std::istream &ins) {
 #endif
 
 //This requires C++14 and above
-#if __cplusplus >= 201402L
+//#if __cplusplus >= 201402L
 //Simplest read possible: int x = read();
 //Credit: /u/9cantthinkofgoodname
 //https://old.reddit.com/r/cpp/comments/gtzsnm/we_need_to_do_better_than_cin_for_new_programmers/fsx6z7x/
 //However, int x = read(ins) is about 20% slower than using read<int>(ins), though
 //There's probably some template tricks we can use to eliminate the while loop when reading from a file
 struct Reader {
+	Reader(std::istream& ins_, const std::string& prompt_) : ins(ins_), prompt(prompt_) {}
 	template<class T>
 		operator T() {
 			while(true) {
 				if(ins.eof()) //We reached the end of file, or the user hit ctrl-d
-					return {}; //Alternatively, we could throw an exception
-				T retval{};
+					return T(); //Alternatively, we could throw an exception
+				T retval;
 				std::cout << prompt;
 				ins >> retval; //If this fails, it's because you need a operator>> defined for your type
 				if(!ins) {
@@ -147,11 +148,11 @@ struct Reader {
 	const std::string prompt;
 };
 
-auto read(const std::string prompt = "") {
-	return Reader{std::cin,prompt};
+Reader read(const std::string prompt = "") {
+	return Reader(std::cin,prompt);
 }
-auto read(std::istream &ins) {
-	return Reader{ins,""};
+Reader read(std::istream &ins) {
+	return Reader(ins,"");
 }
-#endif
+//#endif
 #endif


### PR DESCRIPTION
Referencing #6, I have edited the code such, that everything except the `read_opt`(obviously) functions can be compiled using `clang++ -std=c++98 -Wpedantic -Wall -Werror` without problems. However, #3 still persists.